### PR TITLE
Prevent simulated hashchange link clicks loading the incorrect location

### DIFF
--- a/src/replicant/frame_definition.coffee
+++ b/src/replicant/frame_definition.coffee
@@ -54,7 +54,12 @@ Replicant.registerElement "replicant-frame",
       new Replicant.Location @window?.location
 
     set: (location) ->
-      @iframeElement.src = location.toString()
+      location = location.toString()
+      if location.charAt(0) is "#"
+        currentLocation = @location
+        currentLocation.hash = location
+        location = currentLocation.toString()
+      @iframeElement.src = location
 
   title:
     get: ->

--- a/src/replicant/location.coffee
+++ b/src/replicant/location.coffee
@@ -1,14 +1,23 @@
 class Replicant.Location
   constructor: (href) ->
-    element = document.createElement("a")
-    element.href = href?.toString()
-
-    {@href, @protocol, @host, @hostname,
-     @port, @pathname, @search, @hash,
-     @username, @password} = element
+    @element = document.createElement("a")
+    @element.href = href?.toString()
 
   valueOf: ->
     @href
 
   toString: ->
     @href
+
+  propertyNames = [
+    "href", "protocol", "host", "hostname",
+    "port", "pathname", "search", "hash",
+    "username", "password"
+  ]
+
+  @createProperty = (name) ->
+    Object.defineProperty @prototype, name,
+      get: -> @element[name]
+      set: (value) -> @element[name] = value
+
+  @createProperty name for name in propertyNames

--- a/test/fixtures/default.html
+++ b/test/fixtures/default.html
@@ -14,11 +14,6 @@
           history.replaceState({}, null, event.target.href)
           event.preventDefault()
         })
-
-        document.getElementById("hashchange-link").addEventListener("click", function(event) {
-          location.hash = event.target.hash
-          event.preventDefault()
-        })
       })
     </script>
   </head>

--- a/test/modules/session_test.coffee
+++ b/test/modules/session_test.coffee
@@ -26,6 +26,15 @@ QUnit.module "Replicant.Session"
       assert.equal(navigation.action, "push")
       done()
 
+@frameTest "clicking a hashchange link", (frame, assert, done) ->
+  session = frame.createSession()
+  session.goToLocation "/fixtures/default.html", ->
+    session.clickSelector "#hashchange-link", (navigation) ->
+      assert.equal(navigation.location.pathname, "/fixtures/default.html")
+      assert.equal(navigation.location.hash, "#hash")
+      assert.equal(navigation.action, "pop")
+      done()
+
 @frameTest "waiting for an event", (frame, assert, done) ->
   session = frame.createSession()
   session.goToLocation "/fixtures/event.html", (navigation) ->


### PR DESCRIPTION
This is an attempt to fix #1.

Same page anchors are currently causing the iframe to load `/#hash` rather than maintaining the URI and updating the hash. This results in unexpected behaviour when calling `Session#clickElement`.

This pull request alters the frame's location setter by checking if the value is a hash. If so, it grabs the current location, updates the hash, and generates the correct string representation of the location. In order to do this, `Location` needed to be mutable, so now it gets and sets all its properties on the anchor element dynamically (rather than just getting them all in the constructor).

It's also worth nothing that I removed the event handler on the hash change link on the default test page because it was preventing the location method from being called: https://github.com/sstephenson/replicant/blob/master/src/replicant/session.coffee#L57